### PR TITLE
Use netlify redirects

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,3 +16,4 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - on-merrit-website
+include: [_redirects]

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,6 @@
+# this file is a good guide: https://github.com/rbind/yihui/blob/master/static/_redirects
+# guide on how to do redirects with jekyll: https://wsvincent.com/jekyll-redirects-on-netlify/
+# general docs: https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file
+
+# test redirect for talks
+/thomas/ https://thomasklebel.eu


### PR DESCRIPTION
Hi Ilaria,

netlify has the ability to redirect, which is very easy to set up. This is perfect if we want to have a short link for something, e.g. slides. I like to link the slides of a talk on the slides itself, so people can look them up easily. This could then look like
 `on-merrit.eu/refresh2020` which would lead them to the zenodo record. What I did for now is to forward `on-merrit.eu/thomas` to my website for testing, but this could be removed in the next step, when we add the slides for the refresh2020 talk.

I prefer this option a lot over using bit.ly or something similar, although it comes with a little effort on your side (clicking "merge" 😄 )

Overall, this can be also used on posters or for other materials (although QR-codes are also good for these cases, if people know what to do with them).

Best,
Thomas